### PR TITLE
Migrate to Chainguard node base image

### DIFF
--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,23 @@
+name: "Check for newer image versions"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At the end of every day
+    - cron: "0 0 * * *"
+
+jobs:
+  digest-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: navikt/digestabot@v1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          team: teamdagpenger

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs22-debian12 AS runtime
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22@sha256:a33d079913cb8d448655e3d736501b0a8e107664caee330560e31fc0582d16c0 AS runtime
 WORKDIR /usr/src/app
 
 ENV PORT=3000 \


### PR DESCRIPTION
Replace `gcr.io/distroless` nodejs image with Chainguard node image pinned to digest.

**Hvorfor:**
- Fikser libpng-sårbarheter: CVE-2026-22801, CVE-2026-22695, CVE-2026-25646
- Chainguard-images gir (nesten) 0 sårbarheter

**Endringer:**
- Dockerfile: Byttet base image til Chainguard node med pinnet digest
- Lagt til `.github/workflows/digestabot.yaml` for automatisk digest-oppdatering

**Kompatibilitet:**
- Chainguard node har samme ENTRYPOINT (`node`) som distroless
- WORKDIR og CMD settes eksplisitt i Dockerfile, så ingen funksjonelle endringer
- Kjører som nonroot user (65532) i stedet for root — bedre sikkerhet