### PR TITLE
legg npmjs inn som registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
+registry=https://registry.npmjs.org
 @navikt:registry=https://npm.pkg.github.com
 engine-strict=true


### PR DESCRIPTION
måten støtten for `pnpm` i dependabot er implementert på gjør at alle npm-registries er _opt-in_ dersom `.npmrc` er committa til repoet.

https://github.com/dependabot/dependabot-core/issues/8242#issuecomment-1822046521

dermed, for å få dependabot updates igjen her, kan vi legge inn registry til npmjs :)